### PR TITLE
Produce SimpleCov HTML report if simplecov is installed

### DIFF
--- a/bin/minitest_coverage_report
+++ b/bin/minitest_coverage_report
@@ -14,6 +14,14 @@ ARGV.each do |input_path|
   end
 end
 
+begin
+  require "simplecov"
+  SimpleCov.command_name "Minitest"
+  SimpleCov.add_filter "/test/"
+  SimpleCov::Formatter::HTMLFormatter.new.format SimpleCov::Result.new data
+rescue LoadError
+end
+
 puts "uncv  covr% totl : path"
 puts
 puts data.map { |path, lines|


### PR DESCRIPTION
Currently writes output to `/coverage` just like usual for SimpleCov. A couple questions:

* Should the output formatter be an explicit flag on `minitest_coverage_report`?
* Any desire to standardize paths? Use `/coverage/baseline.json` by default?